### PR TITLE
Notes from review

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -304,9 +304,7 @@ mod tests {
         let new_vote = states[0]
             .sign_vote(Vote {
                 gen: 0,
-                ballot: Ballot::Merge(BTreeSet::from_iter(
-                    states[0].votes.iter().map(|(_, v)| v.clone()),
-                )),
+                ballot: Ballot::Merge(BTreeSet::from_iter(states[0].votes.values().cloned())),
                 faults: Default::default(),
             })
             .unwrap();

--- a/src/mvba/abba/context.rs
+++ b/src/mvba/abba/context.rs
@@ -1,7 +1,16 @@
 use super::{message::Message, message_set::MessageSet};
-use crate::mvba::{broadcaster::Broadcaster, crypto::{public::PubKey, hash}, proposal::Proposal, ProposalChecker};
+use crate::mvba::{
+    broadcaster::Broadcaster,
+    crypto::{hash, public::PubKey},
+    proposal::Proposal,
+    ProposalChecker,
+};
 use minicbor::to_vec;
-use std::{cell::RefCell, collections::{HashSet, HashMap}, rc::Rc};
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    rc::Rc,
+};
 
 pub(super) struct Context {
     pub parties: Vec<PubKey>,
@@ -14,12 +23,12 @@ pub(super) struct Context {
 
 impl Context {
     pub fn new(
-        parties: &Vec<PubKey>,
+        parties: Vec<PubKey>,
         threshold: usize,
         broadcaster: Rc<RefCell<Broadcaster>>,
     ) -> Self {
         Self {
-            parties: parties.clone(),
+            parties,
             threshold,
             proposal_id: None,
             depot: HashMap::new(),

--- a/src/mvba/abba/error.rs
+++ b/src/mvba/abba/error.rs
@@ -1,6 +1,6 @@
+use crate::mvba::{crypto::public::PubKey, proposal::Proposal};
 use minicbor::{decode, encode};
 use thiserror::Error;
-use crate::mvba::{crypto::public::PubKey, proposal::Proposal};
 
 #[derive(Error, Debug, PartialEq)]
 pub enum Error {
@@ -11,21 +11,20 @@ pub enum Error {
     #[error("duplicated proposal: {0:?}")]
     DuplicatedProposal(Proposal),
     #[error("decoding error: {0}")]
-    DecodeError(String),
+    Decode(String),
     #[error("encoding error: {0}")]
-    EncodeError(String),
-
+    Encode(String),
 }
 
 impl<W: std::fmt::Display> From<encode::Error<W>> for Error {
     fn from(err: encode::Error<W>) -> Self {
-        Error::EncodeError(format!("{}", err))
+        Error::Encode(format!("{}", err))
     }
 }
 
 impl From<decode::Error> for Error {
     fn from(err: decode::Error) -> Self {
-        Error::DecodeError(format!("{}", err))
+        Error::Decode(format!("{}", err))
     }
 }
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/mvba/abba/mod.rs
+++ b/src/mvba/abba/mod.rs
@@ -2,10 +2,9 @@ pub(super) mod context;
 pub(super) mod message;
 pub(super) mod state;
 
-mod pre_process;
 mod error;
 mod message_set;
-
+mod pre_process;
 
 use self::error::{Error, Result};
 use self::message::Message;
@@ -21,24 +20,22 @@ use super::ProposalChecker;
 // VCBC is a verifiably authenticatedly c-broadcast protocol.
 // Each party $P_i$ c-broadcasts the value that it proposes to all other parties
 // using verifiable authenticated consistent broadcast.
-pub(crate) struct ABBA {
+pub(crate) struct Abba {
     state: Option<Box<dyn State>>,
 }
 
-impl ABBA {
+impl Abba {
     pub fn new(
-        parties: &Vec<PubKey>,
+        parties: Vec<PubKey>,
         threshold: usize,
         broadcaster: Rc<RefCell<Broadcaster>>,
     ) -> Self {
-        let ctx =
-            context::Context::new(parties, threshold,  broadcaster);
+        let ctx = context::Context::new(parties, threshold, broadcaster);
 
         Self {
             state: Some(Box::new(ProposeState::new(ctx))),
         }
     }
-
 
     pub fn process_message(&mut self, sender: &PubKey, message: &[u8]) -> Result<()> {
         let msg: Message = minicbor::decode(message)?;

--- a/src/mvba/broadcaster.rs
+++ b/src/mvba/broadcaster.rs
@@ -1,5 +1,5 @@
+use super::{bundle::Bundle, crypto::public::PubKey};
 use minicbor::{encode, to_vec};
-use super::{crypto::public::{PubKey}, bundle::Bundle};
 
 pub struct Broadcaster {
     id: u32,
@@ -22,7 +22,7 @@ impl Broadcaster {
 
     pub fn push_message(&mut self, module: &str, message: Vec<u8>) {
         let bdl = Bundle {
-            id:self.id,
+            id: self.id,
             module: module.to_string(),
             message,
         };
@@ -30,7 +30,7 @@ impl Broadcaster {
     }
 
     pub fn take_bundles(&mut self) -> Vec<Vec<u8>> {
-        let mut data  = Vec::with_capacity(self.bundles.len());
+        let mut data = Vec::with_capacity(self.bundles.len());
         for bdl in &self.bundles {
             data.push(to_vec(bdl).unwrap())
         }
@@ -45,7 +45,7 @@ impl Broadcaster {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     #[cfg(test)]

--- a/src/mvba/consensus.rs
+++ b/src/mvba/consensus.rs
@@ -24,7 +24,6 @@ impl Consensus {
         let mut vcbc_map = HashMap::new();
         let broadcaster = Broadcaster::new(id, &self_key);
         let broadcaster_rc = Rc::new(RefCell::new(broadcaster));
-        let proposal_checker_rc = Rc::new(RefCell::new(proposal_checker));
 
         let abba = ABBA::new(&parties, threshold, broadcaster_rc.clone());
 
@@ -34,7 +33,7 @@ impl Consensus {
                 &parties,
                 threshold,
                 broadcaster_rc.clone(),
-                proposal_checker_rc.clone(),
+                proposal_checker,
             );
             vcbc_map.insert(p.clone(), vcbc).unwrap();
         }

--- a/src/mvba/consensus.rs
+++ b/src/mvba/consensus.rs
@@ -1,5 +1,5 @@
 use crate::mvba::{
-    abba::ABBA, broadcaster::Broadcaster, crypto::public::PubKey, proposal::Proposal, vcbc::VCBC,
+    abba::Abba, broadcaster::Broadcaster, crypto::public::PubKey, proposal::Proposal, vcbc::Vcbc,
     ProposalChecker,
 };
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
@@ -7,9 +7,9 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 pub struct Consensus {
     id: u32,
     self_key: PubKey,
-    abba: ABBA,
+    abba: Abba,
     threshold: usize,
-    vcbc_map: HashMap<PubKey, VCBC>,
+    vcbc_map: HashMap<PubKey, Vcbc>,
     broadcaster: Rc<RefCell<Broadcaster>>,
 }
 
@@ -25,12 +25,12 @@ impl Consensus {
         let broadcaster = Broadcaster::new(id, &self_key);
         let broadcaster_rc = Rc::new(RefCell::new(broadcaster));
 
-        let abba = ABBA::new(&parties, threshold, broadcaster_rc.clone());
+        let abba = Abba::new(parties.clone(), threshold, broadcaster_rc.clone());
 
         for p in &parties {
-            let vcbc = VCBC::new(
-                &p,
-                &parties,
+            let vcbc = Vcbc::new(
+                p.clone(),
+                parties.clone(),
                 threshold,
                 broadcaster_rc.clone(),
                 proposal_checker,
@@ -58,7 +58,7 @@ impl Consensus {
 
     pub fn process_bundle(&mut self, data: &[u8]) -> Vec<Vec<u8>> {
         let mut delivered_count = 0;
-        for (_, vcbc) in &self.vcbc_map {
+        for vcbc in self.vcbc_map.values() {
             if vcbc.is_delivered() {
                 delivered_count += 1;
             }

--- a/src/mvba/vcbc/context.rs
+++ b/src/mvba/vcbc/context.rs
@@ -18,16 +18,16 @@ pub(super) struct Context {
 
 impl Context {
     pub fn new(
-        parties: &Vec<PubKey>,
+        parties: Vec<PubKey>,
         threshold: usize,
-        proposer: &PubKey,
+        proposer: PubKey,
         broadcaster: Rc<RefCell<Broadcaster>>,
         proposal_checker: ProposalChecker,
     ) -> Self {
         Self {
-            parties: parties.clone(),
+            parties,
             threshold,
-            proposer: proposer.clone(),
+            proposer,
             proposal: None,
             echos: HashSet::new(),
             broadcaster,

--- a/src/mvba/vcbc/context.rs
+++ b/src/mvba/vcbc/context.rs
@@ -1,5 +1,7 @@
 use super::message::Message;
-use crate::mvba::{broadcaster::Broadcaster, crypto::public::PubKey, proposal::Proposal, ProposalChecker};
+use crate::mvba::{
+    broadcaster::Broadcaster, crypto::public::PubKey, proposal::Proposal, ProposalChecker,
+};
 use minicbor::to_vec;
 use std::{cell::RefCell, collections::HashSet, rc::Rc};
 
@@ -10,7 +12,7 @@ pub(super) struct Context {
     pub proposal: Option<Proposal>,
     pub echos: HashSet<PubKey>,
     pub broadcaster: Rc<RefCell<Broadcaster>>,
-    pub proposal_checker: Rc<RefCell<ProposalChecker>>,
+    pub proposal_checker: ProposalChecker,
     pub delivered: bool,
 }
 
@@ -20,7 +22,7 @@ impl Context {
         threshold: usize,
         proposer: &PubKey,
         broadcaster: Rc<RefCell<Broadcaster>>,
-        proposal_checker: Rc<RefCell<ProposalChecker>>
+        proposal_checker: ProposalChecker,
     ) -> Self {
         Self {
             parties: parties.clone(),
@@ -29,7 +31,7 @@ impl Context {
             proposal: None,
             echos: HashSet::new(),
             broadcaster,
-            proposal_checker: proposal_checker.clone(),
+            proposal_checker,
             delivered: false,
         }
     }

--- a/src/mvba/vcbc/deliver.rs
+++ b/src/mvba/vcbc/deliver.rs
@@ -1,35 +1,20 @@
-use super::context;
-use super::State;
+use super::context::Context;
 use super::error::Result;
+use super::State;
 
-pub(super) struct DeliverState {
-    pub ctx: context::Context
-}
-
-impl DeliverState {
-    pub fn new(ctx: context::Context) -> Self {
-        Self{ctx}
-    }
-}
+pub(super) struct DeliverState;
 
 impl State for DeliverState {
-    fn enter(mut self: Box<Self>) -> Result<Box<dyn State>> {
-        self.context_mut().delivered = true;
+    fn enter(mut self: Box<Self>, ctx: &mut Context) -> Result<Box<dyn State>> {
+        ctx.delivered = true;
         Ok(self)
     }
 
-    fn decide(self: Box<Self>) -> Result<Box<dyn State>> {
-        Ok(self)
+    fn decide(&self, _ctx: &mut Context) -> Result<Option<Box<dyn State>>> {
+        Ok(None)
     }
 
     fn name(&self) -> String {
         "deliver state".to_string()
-    }
-
-    fn context_mut(&mut self) -> &mut context::Context {
-        &mut self.ctx
-    }
-    fn context(&self) -> &context::Context{
-        &self.ctx
     }
 }

--- a/src/mvba/vcbc/deliver.rs
+++ b/src/mvba/vcbc/deliver.rs
@@ -13,8 +13,4 @@ impl State for DeliverState {
     fn decide(&self, _ctx: &mut Context) -> Result<Option<Box<dyn State>>> {
         Ok(None)
     }
-
-    fn name(&self) -> String {
-        "deliver state".to_string()
-    }
 }

--- a/src/mvba/vcbc/deliver.rs
+++ b/src/mvba/vcbc/deliver.rs
@@ -5,7 +5,7 @@ use super::State;
 pub(super) struct DeliverState;
 
 impl State for DeliverState {
-    fn enter(mut self: Box<Self>, ctx: &mut Context) -> Result<Box<dyn State>> {
+    fn enter(self: Box<Self>, ctx: &mut Context) -> Result<Box<dyn State>> {
         ctx.delivered = true;
         Ok(self)
     }

--- a/src/mvba/vcbc/echo.rs
+++ b/src/mvba/vcbc/echo.rs
@@ -29,8 +29,4 @@ impl State for EchoState {
             Ok(None)
         }
     }
-
-    fn name(&self) -> String {
-        "echo state".to_string()
-    }
 }

--- a/src/mvba/vcbc/error.rs
+++ b/src/mvba/vcbc/error.rs
@@ -1,6 +1,6 @@
+use crate::mvba::{crypto::public::PubKey, proposal::Proposal};
 use minicbor::{decode, encode};
 use thiserror::Error;
-use crate::mvba::{crypto::public::PubKey, proposal::Proposal};
 
 #[derive(Error, Debug, PartialEq)]
 pub enum Error {
@@ -11,21 +11,20 @@ pub enum Error {
     #[error("duplicated proposal: {0:?}")]
     DuplicatedProposal(Proposal),
     #[error("decoding error: {0}")]
-    DecodeError(String),
+    Decode(String),
     #[error("encoding error: {0}")]
-    EncodeError(String),
-
+    Encode(String),
 }
 
 impl<W: std::fmt::Display> From<encode::Error<W>> for Error {
     fn from(err: encode::Error<W>) -> Self {
-        Error::EncodeError(format!("{}", err))
+        Error::Encode(format!("{}", err))
     }
 }
 
 impl From<decode::Error> for Error {
     fn from(err: decode::Error) -> Self {
-        Error::DecodeError(format!("{}", err))
+        Error::Decode(format!("{}", err))
     }
 }
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/mvba/vcbc/mod.rs
+++ b/src/mvba/vcbc/mod.rs
@@ -32,7 +32,7 @@ impl VCBC {
         parties: &Vec<PubKey>,
         threshold: usize,
         broadcaster: Rc<RefCell<Broadcaster>>,
-        proposal_checker: Rc<RefCell<ProposalChecker>>,
+        proposal_checker: ProposalChecker,
     ) -> Self {
         let ctx =
             context::Context::new(parties, threshold, proposer, broadcaster, proposal_checker);

--- a/src/mvba/vcbc/mod.rs
+++ b/src/mvba/vcbc/mod.rs
@@ -21,15 +21,15 @@ use super::ProposalChecker;
 // VCBC is a verifiably authenticatedly c-broadcast protocol.
 // Each party $P_i$ c-broadcasts the value that it proposes to all other parties
 // using verifiable authenticated consistent broadcast.
-pub(crate) struct VCBC {
+pub(crate) struct Vcbc {
     ctx: context::Context,
     state: Box<dyn State>,
 }
 
-impl VCBC {
+impl Vcbc {
     pub fn new(
-        proposer: &PubKey,
-        parties: &Vec<PubKey>,
+        proposer: PubKey,
+        parties: Vec<PubKey>,
         threshold: usize,
         broadcaster: Rc<RefCell<Broadcaster>>,
         proposal_checker: ProposalChecker,
@@ -66,10 +66,6 @@ impl VCBC {
 
     pub fn is_delivered(&self) -> bool {
         self.ctx.delivered
-    }
-
-    pub fn proposal(&self) -> &Option<Proposal> {
-        &self.ctx.proposal
     }
 }
 

--- a/src/mvba/vcbc/propose.rs
+++ b/src/mvba/vcbc/propose.rs
@@ -1,48 +1,33 @@
-use super::context;
+use super::context::Context;
 use super::echo::EchoState;
 use super::error::Result;
 use super::message;
 use super::message::Message;
 use super::State;
 
-pub(super) struct ProposeState {
-    pub ctx: context::Context,
-}
-
-impl ProposeState {
-    pub fn new(ctx: context::Context) -> Self {
-        Self{ctx}
-    }
-}
+pub(super) struct ProposeState;
 
 impl State for ProposeState {
-    fn enter(self: Box<Self>) -> Result<Box<dyn State>> {
+    fn enter(self: Box<Self>, ctx: &mut Context) -> Result<Box<dyn State>> {
         Ok(self)
     }
 
-    fn decide(self: Box<Self>) -> Result<Box<dyn State>> {
-        match &self.context().proposal {
+    fn decide(&self, ctx: &mut Context) -> Result<Option<Box<dyn State>>> {
+        match &ctx.proposal {
             Some(proposal) => {
                 let msg = Message {
                     tag: message::MSG_TAG_PROPOSE.to_string(),
                     proposal: proposal.clone(),
                 };
-                self.context().broadcast(&msg);
-                let state = Box::new(EchoState::new( self.ctx ));
-                state.enter()
+                ctx.broadcast(&msg);
+                let state = Box::new(EchoState);
+                Ok(Some(state.enter(ctx)?))
             }
-            None => Ok(self),
+            None => Ok(None),
         }
     }
 
     fn name(&self) -> String {
         "propose state".to_string()
-    }
-
-    fn context_mut(&mut self) -> &mut context::Context {
-        &mut self.ctx
-    }
-    fn context(&self) -> &context::Context {
-        &self.ctx
     }
 }

--- a/src/mvba/vcbc/propose.rs
+++ b/src/mvba/vcbc/propose.rs
@@ -26,8 +26,4 @@ impl State for ProposeState {
             None => Ok(None),
         }
     }
-
-    fn name(&self) -> String {
-        "propose state".to_string()
-    }
 }

--- a/src/mvba/vcbc/state.rs
+++ b/src/mvba/vcbc/state.rs
@@ -30,7 +30,7 @@ pub(super) trait State {
                 return Err(Error::DuplicatedProposal(proposal.clone()));
             }
         }
-        if !(ctx.proposal_checker)(&proposal) {
+        if !(ctx.proposal_checker)(proposal) {
             return Err(Error::InvalidProposal(proposal.clone()));
         }
         ctx.proposal = Some(proposal.clone());
@@ -50,7 +50,7 @@ pub(super) trait State {
             }
             message::MSG_TAG_ECHO => {
                 self.set_proposal(&msg.proposal, ctx)?;
-                self.add_echo(&sender, ctx);
+                self.add_echo(sender, ctx);
             }
             _ => {}
         }

--- a/src/mvba/vcbc/state.rs
+++ b/src/mvba/vcbc/state.rs
@@ -10,9 +10,6 @@ pub(super) trait State {
     // checks the context and decides to move to new state.
     fn decide(&self, ctx: &mut context::Context) -> Result<Option<Box<dyn State>>>;
 
-    // return the name of the state
-    fn name(&self) -> String;
-
     // adds echo from the echoer for the context proposal
     fn add_echo(&mut self, echoer: &PubKey, ctx: &mut context::Context) {
         ctx.echos.insert(echoer.clone());

--- a/src/mvba/vcbc/state.rs
+++ b/src/mvba/vcbc/state.rs
@@ -30,7 +30,7 @@ pub(super) trait State {
                 return Err(Error::DuplicatedProposal(proposal.clone()));
             }
         }
-        if !(ctx.proposal_checker.borrow())(&proposal) {
+        if !(ctx.proposal_checker)(&proposal) {
             return Err(Error::InvalidProposal(proposal.clone()));
         }
         ctx.proposal = Some(proposal.clone());

--- a/src/mvba/vcbc/state.rs
+++ b/src/mvba/vcbc/state.rs
@@ -1,57 +1,56 @@
 use super::error::{Error, Result};
-use super::{context, message};
 use super::message::Message;
+use super::{context, message};
 use crate::mvba::{crypto::public::PubKey, proposal::Proposal};
 
 pub(super) trait State {
     // enters to the new state
-    fn enter(self: Box<Self>) -> Result<Box<dyn State>>;
+    fn enter(self: Box<Self>, ctx: &mut context::Context) -> Result<Box<dyn State>>;
 
     // checks the context and decides to move to new state.
-    fn decide(self: Box<Self>) -> Result<Box<dyn State>>;
+    fn decide(&self, ctx: &mut context::Context) -> Result<Option<Box<dyn State>>>;
 
     // return the name of the state
     fn name(&self) -> String;
 
-    // returns the mutable version of context
-    fn context_mut(&mut self) -> &mut context::Context;
-
-    // returns the immutable version of context
-    fn context(&self) -> &context::Context;
-
     // adds echo from the echoer for the context proposal
-    fn add_echo(&mut self, echoer: &PubKey) {
-        self.context_mut().echos.insert(echoer.clone());
+    fn add_echo(&mut self, echoer: &PubKey, ctx: &mut context::Context) {
+        ctx.echos.insert(echoer.clone());
     }
 
-    fn set_proposal(&mut self, proposal: &Proposal) -> Result<()> {
-        if proposal.proposer != self.context().proposer {
+    fn set_proposal(&mut self, proposal: &Proposal, ctx: &mut context::Context) -> Result<()> {
+        if proposal.proposer != ctx.proposer {
             return Err(Error::InvalidProposer(
                 proposal.proposer.clone(),
-                self.context().proposer.clone(),
+                ctx.proposer.clone(),
             ));
         }
-        if let Some(context_proposal) = self.context().proposal.as_ref() {
+        if let Some(context_proposal) = ctx.proposal.as_ref() {
             if context_proposal != proposal {
                 return Err(Error::DuplicatedProposal(proposal.clone()));
             }
         }
-        if !(self.context().proposal_checker.borrow())(&proposal) {
+        if !(ctx.proposal_checker.borrow())(&proposal) {
             return Err(Error::InvalidProposal(proposal.clone()));
         }
-        self.context_mut().proposal = Some(proposal.clone());
+        ctx.proposal = Some(proposal.clone());
 
         Ok(())
     }
 
-     fn process_message(&mut self, sender: &PubKey, msg: &Message) -> Result<()> {
+    fn process_message(
+        &mut self,
+        sender: &PubKey,
+        msg: &Message,
+        ctx: &mut context::Context,
+    ) -> Result<()> {
         match msg.tag.as_str() {
             message::MSG_TAG_PROPOSE => {
-                self.set_proposal(&msg.proposal)?;
+                self.set_proposal(&msg.proposal, ctx)?;
             }
             message::MSG_TAG_ECHO => {
-                self.set_proposal(&msg.proposal)?;
-                self.add_echo(&sender);
+                self.set_proposal(&msg.proposal, ctx)?;
+                self.add_echo(&sender, ctx);
             }
             _ => {}
         }

--- a/src/mvba/vcbc/tests.rs
+++ b/src/mvba/vcbc/tests.rs
@@ -8,7 +8,7 @@ struct TestData {
     party_y: PubKey,
     party_b: PubKey,
     party_s: PubKey,
-    vcbc: VCBC,
+    vcbc: Vcbc,
     broadcaster: Rc<RefCell<Broadcaster>>,
     proposal: Proposal,
 }
@@ -43,7 +43,13 @@ impl TestData {
             _ => panic!("invalid proposer"),
         };
         let broadcaster = Rc::new(RefCell::new(Broadcaster::new(random(), &party_x)));
-        let vcbc = VCBC::new(&proposer, &parties, 1, broadcaster.clone(), valid_proposal);
+        let vcbc = Vcbc::new(
+            proposer.clone(),
+            parties,
+            1,
+            broadcaster.clone(),
+            valid_proposal,
+        );
 
         // Creating a random proposal
         let mut rng = rand::thread_rng();
@@ -106,7 +112,7 @@ fn test_normal_case() {
     let mut t = TestData::new("x");
 
     assert!(!t.vcbc.is_delivered());
-    assert_eq!(t.vcbc.proposal(), &None);
+    assert_eq!(t.vcbc.ctx.proposal, None);
     assert!(t.vcbc.ctx.echos.is_empty());
 
     t.vcbc.propose(&t.proposal).unwrap();
@@ -114,7 +120,7 @@ fn test_normal_case() {
     t.vcbc.process_message(&t.party_s, &t.echo_msg()).unwrap();
 
     assert!(t.vcbc.is_delivered());
-    assert_eq!(t.vcbc.proposal(), &Some(t.proposal));
+    assert_eq!(t.vcbc.ctx.proposal, Some(t.proposal));
     let echos = &t.vcbc.ctx.echos;
     assert!(echos.contains(&t.party_x));
     assert!(echos.contains(&t.party_y));

--- a/src/mvba/vcbc/tests.rs
+++ b/src/mvba/vcbc/tests.rs
@@ -43,19 +43,12 @@ impl TestData {
             _ => panic!("invalid proposer"),
         };
         let broadcaster = Rc::new(RefCell::new(Broadcaster::new(random(), &party_x)));
-        let proposal_checker: Rc<RefCell<ProposalChecker>> = Rc::new(RefCell::new(valid_proposal));
-        let vcbc = VCBC::new(
-            &proposer,
-            &parties,
-            1,
-            broadcaster.clone(),
-            proposal_checker.clone(),
-        );
+        let vcbc = VCBC::new(&proposer, &parties, 1, broadcaster.clone(), valid_proposal);
 
         // Creating a random proposal
         let mut rng = rand::thread_rng();
         let proposal = Proposal {
-            proposer: proposer.clone(),
+            proposer,
             value: (0..100).map(|_| rng.gen_range(0..64)).collect(),
             proof: (0..100).map(|_| rng.gen_range(0..64)).collect(),
         };
@@ -149,7 +142,7 @@ fn test_delayed_propose_message() {
 #[test]
 fn test_invalid_proposal() {
     let mut t = TestData::new("b");
-    t.vcbc.ctx.proposal_checker = Rc::new(RefCell::new(invalid_proposal));
+    t.vcbc.ctx.proposal_checker = invalid_proposal;
 
     assert_eq!(
         t.vcbc.process_message(&t.party_b, &t.propose_msg()).err(),

--- a/src/mvba/vcbc/tests.rs
+++ b/src/mvba/vcbc/tests.rs
@@ -105,7 +105,7 @@ fn test_propose() {
     t.should_propose();
     t.should_echo();
 
-    assert!(t.vcbc.state.unwrap().context().echos.contains(&t.party_x));
+    assert!(t.vcbc.ctx.echos.contains(&t.party_x));
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn test_normal_case() {
 
     assert!(!t.vcbc.is_delivered());
     assert_eq!(t.vcbc.proposal(), &None);
-    assert!(t.vcbc.state.as_ref().unwrap().context().echos.is_empty());
+    assert!(t.vcbc.ctx.echos.is_empty());
 
     t.vcbc.propose(&t.proposal).unwrap();
     t.vcbc.process_message(&t.party_y, &t.echo_msg()).unwrap();
@@ -122,7 +122,7 @@ fn test_normal_case() {
 
     assert!(t.vcbc.is_delivered());
     assert_eq!(t.vcbc.proposal(), &Some(t.proposal));
-    let echos = &t.vcbc.state.as_ref().unwrap().context().echos;
+    let echos = &t.vcbc.ctx.echos;
     assert!(echos.contains(&t.party_x));
     assert!(echos.contains(&t.party_y));
     assert!(echos.contains(&t.party_s));
@@ -149,12 +149,7 @@ fn test_delayed_propose_message() {
 #[test]
 fn test_invalid_proposal() {
     let mut t = TestData::new("b");
-    t.vcbc
-        .state
-        .as_mut()
-        .unwrap()
-        .context_mut()
-        .proposal_checker = Rc::new(RefCell::new(invalid_proposal));
+    t.vcbc.ctx.proposal_checker = Rc::new(RefCell::new(invalid_proposal));
 
     assert_eq!(
         t.vcbc.process_message(&t.party_b, &t.propose_msg()).err(),

--- a/tests/sn_membership.rs
+++ b/tests/sn_membership.rs
@@ -184,7 +184,7 @@ fn test_membership_round_robin_split_vote() -> Result<()> {
 
         let proc_0_gen = net.procs[0].gen;
         let expected_members = net.procs[0].members(proc_0_gen)?;
-        assert_eq!(expected_members, BTreeSet::from_iter(0..(nprocs as u8)));
+        assert_eq!(expected_members, BTreeSet::from_iter(0..nprocs));
 
         for i in 0..nprocs {
             let gen = net.procs[i as usize].gen;


### PR DESCRIPTION
Some changes:

1. Move up `ctx` from `State` to `Vcbc`. State methods now take `Context` as an argument instead of holding on to `Context` inside the state's struct. This remove a few unwraps, slims down the State trait a bit and removes the need for `Option<..>` in `Option<Box<dyn State>>`.
2. State::decide returns an Option<Box<dyn State>>, it's Some(state) if we are doing a state transition, None otherwise.
3. Remove `Rc<RefCell<.>>` wrappers around the proposal_checker, those were unnecessary.
4. Run Clippy and Rustfmt (please make that a habit!)